### PR TITLE
Supports interface compatibility fix

### DIFF
--- a/src/contracts/mocks/ERC1155MetaMintBurnMock.sol
+++ b/src/contracts/mocks/ERC1155MetaMintBurnMock.sol
@@ -25,7 +25,7 @@ contract ERC1155MetaMintBurnMock is ERC1155Meta, ERC1155MintBurn, ERC1155Metadat
   ) public override(
     ERC1155,
     ERC1155Metadata
-  ) pure virtual returns (bool) {
+  ) view virtual returns (bool) {
     return super.supportsInterface(_interfaceID);
   }
 

--- a/src/contracts/mocks/ERC1155MetaMintBurnMock.sol
+++ b/src/contracts/mocks/ERC1155MetaMintBurnMock.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 
 import "../tokens/ERC1155/ERC1155Meta.sol";
 import "../tokens/ERC1155/ERC1155MintBurn.sol";

--- a/src/contracts/mocks/ERC1155MetaMintBurnPackedBalanceMock.sol
+++ b/src/contracts/mocks/ERC1155MetaMintBurnPackedBalanceMock.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 
 import "../tokens/ERC1155PackedBalance/ERC1155MetaPackedBalance.sol";
 import "../tokens/ERC1155PackedBalance/ERC1155MintBurnPackedBalance.sol";

--- a/src/contracts/mocks/ERC1155MetaMintBurnPackedBalanceMock.sol
+++ b/src/contracts/mocks/ERC1155MetaMintBurnPackedBalanceMock.sol
@@ -29,7 +29,7 @@ contract ERC1155MetaMintBurnPackedBalanceMock is ERC1155MintBurnPackedBalance, E
   ) public override(
     ERC1155PackedBalance,
     ERC1155Metadata
-  ) pure virtual returns (bool) {
+  ) view virtual returns (bool) {
     return super.supportsInterface(_interfaceID);
   }
 

--- a/src/contracts/mocks/ERC1155MetadataMock.sol
+++ b/src/contracts/mocks/ERC1155MetadataMock.sol
@@ -60,7 +60,7 @@ contract ERC1155MetadataMock is ERC1155MintBurn, ERC1155Metadata {
   ) public override(
     ERC1155,
     ERC1155Metadata
-  ) pure virtual returns (bool) {
+  ) view virtual returns (bool) {
     return super.supportsInterface(_interfaceID);
   }
 }

--- a/src/contracts/mocks/ERC1155MetadataMock.sol
+++ b/src/contracts/mocks/ERC1155MetadataMock.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 
 import "../tokens/ERC1155/ERC1155MintBurn.sol";
 import "../tokens/ERC1155/ERC1155Metadata.sol";

--- a/src/contracts/mocks/ERC1155MintBurnMock.sol
+++ b/src/contracts/mocks/ERC1155MintBurnMock.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 
 import "../tokens/ERC1155/ERC1155MintBurn.sol";
 import "../tokens/ERC1155/ERC1155Metadata.sol";

--- a/src/contracts/mocks/ERC1155MintBurnMock.sol
+++ b/src/contracts/mocks/ERC1155MintBurnMock.sol
@@ -24,7 +24,7 @@ contract ERC1155MintBurnMock is ERC1155MintBurn, ERC1155Metadata {
   ) public override(
     ERC1155,
     ERC1155Metadata
-  ) pure virtual returns (bool) {
+  ) view virtual returns (bool) {
     return super.supportsInterface(_interfaceID);
   }
 

--- a/src/contracts/mocks/ERC1155MintBurnMockOwned.sol
+++ b/src/contracts/mocks/ERC1155MintBurnMockOwned.sol
@@ -25,7 +25,7 @@ contract ERC1155MintBurnMockOwned is ERC1155MintBurn, Ownable, ERC1155Metadata {
   ) public override(
     ERC1155,
     ERC1155Metadata
-  ) pure virtual returns (bool) {
+  ) view virtual returns (bool) {
     return super.supportsInterface(_interfaceID);
   }
 

--- a/src/contracts/mocks/ERC1155MintBurnMockOwned.sol
+++ b/src/contracts/mocks/ERC1155MintBurnMockOwned.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 
 import "../tokens/ERC1155/ERC1155MintBurn.sol";
 import "../tokens/ERC1155/ERC1155Metadata.sol";

--- a/src/contracts/mocks/ERC1155MintBurnPackedBalanceMock.sol
+++ b/src/contracts/mocks/ERC1155MintBurnPackedBalanceMock.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 
 import "../tokens/ERC1155PackedBalance/ERC1155MintBurnPackedBalance.sol";
 import "../tokens/ERC1155/ERC1155Metadata.sol";

--- a/src/contracts/mocks/ERC1155MintBurnPackedBalanceMock.sol
+++ b/src/contracts/mocks/ERC1155MintBurnPackedBalanceMock.sol
@@ -28,7 +28,7 @@ contract ERC1155MintBurnPackedBalanceMock is ERC1155MintBurnPackedBalance, ERC11
   ) public override(
     ERC1155PackedBalance,
     ERC1155Metadata
-  ) pure virtual returns (bool) {
+  ) view virtual returns (bool) {
     return super.supportsInterface(_interfaceID);
   }
 

--- a/src/contracts/mocks/ERC2981GlobalMock.sol
+++ b/src/contracts/mocks/ERC2981GlobalMock.sol
@@ -22,7 +22,7 @@ contract ERC2981GlobalMock is ERC1155MintBurnMock, ERC2981Global {
     _setGlobalRoyaltyInfo(_recipient, _royaltyBasisPoints);
   }
 
-  function supportsInterface(bytes4 _interfaceID) public override(ERC1155MintBurnMock, ERC2981Global) virtual pure returns (bool) {
+  function supportsInterface(bytes4 _interfaceID) public override(ERC1155MintBurnMock, ERC2981Global) virtual view returns (bool) {
     return super.supportsInterface(_interfaceID);
   }
 }

--- a/src/contracts/tokens/ERC1155/ERC1155.sol
+++ b/src/contracts/tokens/ERC1155/ERC1155.sol
@@ -222,7 +222,7 @@ contract ERC1155 is IERC1155, ERC165 {
    * @param _interfaceID  The interface identifier, as specified in ERC-165
    * @return `true` if the contract implements `_interfaceID` and
    */
-  function supportsInterface(bytes4 _interfaceID) public override(ERC165, IERC165) virtual pure returns (bool) {
+  function supportsInterface(bytes4 _interfaceID) public override(ERC165, IERC165) virtual view returns (bool) {
     if (_interfaceID == type(IERC1155).interfaceId) {
       return true;
     }

--- a/src/contracts/tokens/ERC1155/ERC1155Meta.sol
+++ b/src/contracts/tokens/ERC1155/ERC1155Meta.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 
 import "./ERC1155.sol";
 import "../../interfaces/IERC20.sol";

--- a/src/contracts/tokens/ERC1155/ERC1155Metadata.sol
+++ b/src/contracts/tokens/ERC1155/ERC1155Metadata.sol
@@ -73,7 +73,7 @@ contract ERC1155Metadata is IERC1155Metadata, ERC165 {
    * @param _interfaceID  The interface identifier, as specified in ERC-165
    * @return `true` if the contract implements `_interfaceID` and
    */
-  function supportsInterface(bytes4 _interfaceID) public pure virtual override returns (bool) {
+  function supportsInterface(bytes4 _interfaceID) public view virtual override returns (bool) {
     if (_interfaceID == type(IERC1155Metadata).interfaceId) {
       return true;
     }

--- a/src/contracts/tokens/ERC1155PackedBalance/ERC1155MetaPackedBalance.sol
+++ b/src/contracts/tokens/ERC1155PackedBalance/ERC1155MetaPackedBalance.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
 
 import "./ERC1155PackedBalance.sol";
 import "../../interfaces/IERC20.sol";

--- a/src/contracts/tokens/ERC1155PackedBalance/ERC1155PackedBalance.sol
+++ b/src/contracts/tokens/ERC1155PackedBalance/ERC1155PackedBalance.sol
@@ -388,7 +388,7 @@ contract ERC1155PackedBalance is IERC1155, ERC165 {
    * @param _interfaceID  The interface identifier, as specified in ERC-165
    * @return `true` if the contract implements `_interfaceID` and
    */
-  function supportsInterface(bytes4 _interfaceID) public override(ERC165, IERC165) virtual pure returns (bool) {
+  function supportsInterface(bytes4 _interfaceID) public override(ERC165, IERC165) virtual view returns (bool) {
     if (_interfaceID == type(IERC1155).interfaceId) {
       return true;
     }

--- a/src/contracts/tokens/ERC2981/ERC2981Global.sol
+++ b/src/contracts/tokens/ERC2981/ERC2981Global.sol
@@ -60,7 +60,7 @@ contract ERC2981Global is IERC2981, ERC165 {
    * @param _interfaceID  The interface identifier, as specified in ERC-165
    * @return `true` if the contract implements `_interfaceID` and
    */
-  function supportsInterface(bytes4 _interfaceID) public override(ERC165, IERC165) virtual pure returns (bool) {
+  function supportsInterface(bytes4 _interfaceID) public override(ERC165, IERC165) virtual view returns (bool) {
     if (_interfaceID == type(IERC2981).interfaceId) {
       return true;
     }

--- a/src/contracts/utils/ERC165.sol
+++ b/src/contracts/utils/ERC165.sol
@@ -7,7 +7,7 @@ abstract contract ERC165 is IERC165 {
    * @param _interfaceID The interface identifier, as specified in ERC-165
    * @return `true` if the contract implements `_interfaceID`
    */
-  function supportsInterface(bytes4 _interfaceID) virtual override public pure returns (bool) {
+  function supportsInterface(bytes4 _interfaceID) virtual override public view returns (bool) {
     return _interfaceID == this.supportsInterface.selector;
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/erc-1155",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "ERC-1155 implementation for Ethereum",
   "repository": "https://github.com/0xsequence/erc-1155",
   "homepage": "https://sequence.build",


### PR DESCRIPTION
[OpenZeppelin](https://www.npmjs.com/package/@openzeppelin/contracts), [ERC721A](https://www.npmjs.com/package/erc721a) and others use the `view` modifier on `supportsInterface(bytes4 _interfaceId)`. This causes compatbility issues with 0xSequence libraries as we use `pure`. 
This PR updates Sequence implementations to match those other libraries. 