### PR TITLE
virtual external functions are public

### DIFF
--- a/src/contracts/tokens/ERC1155/ERC1155.sol
+++ b/src/contracts/tokens/ERC1155/ERC1155.sol
@@ -154,7 +154,7 @@ contract ERC1155 is IERC1155, ERC165 {
    * @param _approved  True if the operator is approved, false to revoke approval
    */
   function setApprovalForAll(address _operator, bool _approved)
-    external virtual override
+    public virtual override
   {
     // Update operator status
     operators[msg.sender][_operator] = _approved;

--- a/src/contracts/tokens/ERC1155PackedBalance/ERC1155PackedBalance.sol
+++ b/src/contracts/tokens/ERC1155PackedBalance/ERC1155PackedBalance.sol
@@ -205,7 +205,7 @@ contract ERC1155PackedBalance is IERC1155, ERC165 {
    * @param _approved  True if the operator is approved, false to revoke approval
    */
   function setApprovalForAll(address _operator, bool _approved)
-    external virtual override
+    public virtual override
   {
     // Update operator status
     operators[msg.sender][_operator] = _approved;

--- a/src/contracts/tokens/ERC2981/ERC2981Global.sol
+++ b/src/contracts/tokens/ERC2981/ERC2981Global.sol
@@ -44,7 +44,7 @@ contract ERC2981Global is IERC2981, ERC165 {
   function royaltyInfo(
     uint256, 
     uint256 _saleCost
-  ) external view virtual override returns (address receiver, uint256 royaltyAmount) {
+  ) public view virtual override returns (address receiver, uint256 royaltyAmount) {
     FeeInfo memory info = globalRoyaltyInfo;
     return (info.receiver, _saleCost * info.feeBasisPoints / 1000);
   }


### PR DESCRIPTION
Makes `external virtual` functions `public virtual` so that overriding implementations may hook back into the original function with `super.`